### PR TITLE
[WIP] Add jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+package-lock.json
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Smart components for using parts of BEM methodology with React",
   "main": "lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -24,5 +24,9 @@
   "homepage": "https://github.com/kizu/bemto-components#readme",
   "dependencies": {
     "react": "15.4.1"
+  },
+  "devDependencies": {
+    "jest": "^21.2.1",
+    "react-test-renderer": "^15.4.1"
   }
 }

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`with boolean modifier 1`] = `
+<div
+  className="block block_mod"
+/>
+`;
+
+exports[`with class name only 1`] = `
+<div
+  className="block block_mod_value"
+/>
+`;
+
+exports[`with multiple classes 1`] = `
+<div
+  className="block1 block2 block1_mod_value block2_mod_value"
+/>
+`;
+
+exports[`with multiple external classes 1`] = `
+<div
+  className="block1 block2 block1_mod_value block2_mod_value"
+/>
+`;
+
+exports[`with tag and explicit class name 1`] = `
+<div
+  className="block block_mod_value"
+/>
+`;
+
+exports[`with tag and explicit id and class name 1`] = `
+<div
+  className="block block_mod_value"
+  id="id"
+/>
+`;
+
+exports[`with tag name and external className 1`] = `
+<div
+  className="block block_mod_value"
+/>
+`;

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,68 @@
+const React = require('react');
+const bemto = require('..');
+const renderer = require('react-test-renderer');
+
+const testSnapshot = function(tag, props, children) {
+  const component = renderer.create(
+    React.createElement(
+      tag,
+      props,
+      children
+    )
+  );
+
+  expect(component.toJSON()).toMatchSnapshot();
+}
+
+test('with tag name and external className', () => {
+  const tag = bemto('div');
+  testSnapshot(
+    bemto('div'),
+    { className: 'block', _mod: 'value' }
+  );
+});
+
+test('with boolean modifier', () => {
+  testSnapshot(
+    bemto('div'),
+    { className: 'block', _mod: true }
+  );
+});
+
+test('with class name only', () => {
+  testSnapshot(
+    bemto('.block'),
+    { _mod: 'value' }
+  );
+});
+
+test('with tag and explicit class name', () => {
+  testSnapshot(
+    bemto('span.block'),
+    { _mod: 'value' }
+  );
+});
+
+test('with tag and explicit id and class name', () => {
+  testSnapshot(
+    bemto('span#id.block'),
+    { _mod: 'value' }
+  );
+});
+
+test('with multiple classes', () => {
+  testSnapshot(
+    bemto('.block1.block2'),
+    { _mod: 'value' }
+  );
+});
+
+test('with multiple external classes', () => {
+  testSnapshot(
+    bemto('div'),
+    {
+      className: 'block1 block2',
+      _mod: 'value'
+    }
+  );
+});


### PR DESCRIPTION
Uses jest's snapshot testing. At the moment, snapshots show few issues:

1. Original `_mod` prop is still forwarded to a component. This will be a problem
in react 16.

2. In case of tag string with explicit class name, extra classes for
modifiers (`_modName`) are added for each modifier.

It will probably be a good idea to fix those issues before merging a test. I might have time to look into that later this week.