### PR TITLE
Added a way to define the element when defining a bemto block

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## v1.3.0 (in development)
 
-- [WIP] Added a way to define the element when defining a bemto block.
+- Added a way to define the element when defining a bemto block.
+- Added a way to pass content to those elements from the block call.
 - Added a way to pass options object as well/instead of a tagString.
 - Made __BemtoElem API a bit easier to use.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v1.3.0 (in development)
 
+- [WIP] Added a way to define the element when defining a bemto block.
 - Added a way to pass options object as well/instead of a tagString.
 - Made __BemtoElem API a bit easier to use.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are a lot of things `bemto-components` would do in the future, but for now
 
 2. `bemto-components` gives you a way to easily create a component from a simple string that can contain an optional tag name (for now it defaults to `div` if omitted, but more on it coming, see the [3.]) and a bunch of classNames: `bemto('span.myClass1.myClass2')` would create a span component with the `myClass1 myClass2`, which would have all the other bemto features (like the applying of modifiers).
 
-3. `bemto-components` gives you a way to easily create BEM “Elements” for your components.
+3. `bemto-components` gives you a way to easily create BEM “Elements” for your components. And you have a lot of ways to do it. Like, you can generate the HTML structure of the block with all the elements right at the definition and then pass content to those elements when you call your block.
 
 4. `bemto-components` allows you to think less about handling your components' tag names by embracing some prop-based polymorphism. For example, you can ommit explicit tagnames for some HTML elements: anchors when you'd use `href` attribute, images for components with `src`, labels for components `for`. Buttons for `type` prop with `button` or `submit` values, and inputs for other `type` values. This makes it really easy to make polymorphic menu items (that are spans or divs when no `href` given, and proper links when the `href` is given), or buttons that could be `button`s by default, but would convert themselves to anchors when `href` given.
 
@@ -92,7 +92,138 @@ Usage:
 
 Just like this.
 
-## Example usage for elements
+## Example usage for elements (on definition)
+
+Whenever you define your bemto block, you can pass an object that would describe its content. This would allow you both to generate the desired HTML structure of the element right away, and link the created elements inside with the corresponding props on the block.
+
+For example, what if we'd want a block that would have an extra wrapper inside for its content, but as well would have two helper elements at the start of the block, one of which could be optional? Easy!
+
+```jsx
+const Bento = bemto('.Bento', {
+  content: [
+    { elem: 'Helper1' },
+    { elem: 'Helper2', optional: true },
+    { elem: 'Content', children: true }
+  ]
+});
+```
+
+Then we can call it like that:
+
+```jsx
+<Bento>Hello</Bento>
+```
+
+And we'd get this HTML for it:
+
+```html
+<div class="Bento">
+  <div class="Bento__Helper1"></div>
+  <div class="Bento__Content">
+    Hello
+  </div>
+</div>
+```
+
+As you can see, the `Helper1` element is always rendered, while the `Helper2` is not there. That leads to a question: what is the prerequisite for this element to appear? That leads to the next part:
+
+### Passing content and props to the elements
+
+Yep, whenever you define a block with its elements, you get also a way to _control_ those elements. What if we'd call our block like this?
+
+```jsx
+<Bento __Helper1='foo' __Helper2='bar'>
+  Hello
+</Bento>
+```
+
+Can you guess what we'd get?
+
+```html
+<div class="Bento">
+  <div class="Bento__Helper1">foo</div>
+  <div class="Bento__Helper2">bar</div>
+  <div class="Bento__Content">
+    Hello
+  </div>
+</div>
+```
+
+You can pass strings, arrays or other html/react elements inside. But what if you'd want to change some of those elements a bit? Easy:
+
+```jsx
+<Bento
+  __Helper1={{
+    content: 'foo',
+    props: { _mod: true }
+  }}
+  __Helper2={{
+    content: 'bar',
+    props: { href: '#x' }
+  }}
+>
+  Hello
+</Bento>
+```
+
+Whenever you pass a special object, you're getting a way to define props on this element (and you can use `content` for its children). And, of course, all other bemto features work on those elements: the modifiers modify this exact element, and the tags would be polymorphic as well.
+
+### Styled-components
+
+What I like about these elements the most is that there is build-in support for styled-components. Look:
+
+```jsx
+const Bento = styled(bemto({
+  content: [
+    { elem: 'Helper1' },
+    { elem: 'Helper2', optional: true },
+    { elem: 'Content', children: true }
+  ]
+}))`
+  border: 1px solid;
+
+  &__Helper1 {
+    background: blue;
+
+    &_mod {
+      background: lime;
+    }
+  }
+
+  &__Helper2 {
+    background: red;
+  }
+
+  &__Content {
+    padding: 10px;
+  }
+`;
+```
+
+That's it! We can just wrap our bemto block with `styled()` and all of the automatically generated classNames would work for elements and modifiers.
+
+But wait. The best part: all of this works with `.extend`!
+
+```jsx
+const CuteBentoBox = Bento.extend`
+  background: yellow;
+
+  &__Helper1,
+  &__Helper2 {
+    padding: 5px;
+  }
+`;
+```
+
+And then when you'd use `<CuteBentoBox>` you'd get all of the stuff you've defined for `<Bento>`, as well as all the new styles. This allows you to create not just abstract styled atomic components, but more complex structures that would still be extendable and wouldn't have specificity problems or conflicts, as all the classNames would be prefixed by the styled-components-generated className, and each element would have just a single className in selector (compare with cases when you'd use something like `${Bento} > &` for your child components when doing stuff in a traditional styled-components way).
+
+- - -
+
+There are a lot of other planned features around this kind of elements, but those are the base of it and should be enough to create really complex components in a really easy way.
+
+## Example usage for elements (postfactum API)
+
+(disclaimer: all of these methods were created before the abovementioned creation-on-definition, so I'm not sure how useful all of this would be now, but still!)
 
 For bemto-components you can call `.elem()` method to create an element:
 
@@ -232,30 +363,18 @@ This new `MyBlock` would be rendered with all the styles combined and it would h
 
 Note: it could be possible to create a sligtly better API, but that would mean there'd be more logic involved, and this `__BemtoElem` way should be the cheapest and would have the lower amount of wrappers than alternatives.
 
-## Hint: if you have styled-components, you can emulate elements even without this lib:
+- - -
 
-It is already possible to _kinda_ use Elements from BEM with react and/or styled components without adding anything extra:
+To be continued!
 
-```jsx
-const Block = styled.div`
-  background: red;
-`
+If you'd like to follow on the bemto-components progress, [follow me on twitter](https://twitter.com/kizmarh/).
 
-Block.Element = styled.span`
-  background: blue;
-  
-  ${Block}:hover & {
-    background: lime;
-  }
-`
-```
+- - -
 
-And in usage:
+Copyright (c) 2017 Roman Komarov <kizu@kizu.ru>
 
-```jsx
-<Block>
-  <Block.Element>Hewwo!</Block.Element>
-</Block>
-```
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-This way you can easily couple the element with its block. I have some plans on how we could use more familiar to BEM `__elements`, so keep in touch if interested!
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,8 +114,8 @@ const unfoldChildren = function(props, generator) {
       return item;
     }
     if (item.type === 'elemContent') {
-      const matchingElemProp = props['__' + item.parents.filter(name => props['__' + name])[0]];
-      return matchingElemProp && matchingElemProp.content || matchingElemProp;
+      const matchingElemProp = props['__' + item.parents.filter(name => props['__' + name]).reverse()[0]];
+      return matchingElemProp && matchingElemProp.content || typeof matchingElemProp === 'string' && matchingElemProp;
     }
     if (elemName) {
       if (item.optional && !elemProp) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,10 +120,14 @@ const unfoldChildren = function(props, generator) {
       if (item.optional && !elemProp) {
         return;
       }
+      const parsedTagString = parseTagString(item.tagString);
+      if (item.tag) { parsedTagString.tag = item.tag; }
+      if (item.className) { parsedTagString.className += ' ' + item.className; }
       const myProps = Object.assign({
         __BemtoElem: {
           name: elemName,
-          props: { key: index }
+          props: { key: index },
+          parsedTagString: parsedTagString
         }
       }, props);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,8 +41,8 @@ const selectTag = function(props, defaultTag) {
   return defaultTag;
 };
 
-const ensureArray = function(content) {
-  return content.constructor === Array ? content : [content];
+const applyToAll = function(content, func) {
+  return (content.constructor === Array) ? content.map(func) : func(content);
 };
 
 // Getting the options from the flexible arguments
@@ -109,9 +109,14 @@ const gatherOptions = function(outerOptions, baseOptions) {
 const unfoldChildren = function(props, generator) {
   const unfoldFunction = function(item, index) {
     const elemName = item.name || item.elem;
-    const elemProp = props['__' + elemName] || item.parents && props['__' + item.parents.filter(name => props['__' + name]).reverse()[0]];
+    let elemProp = props['__' + elemName] || item.parents && props['__' + item.parents.filter(name => props['__' + name]).reverse()[0]];
     if (typeof item === 'string') {
       return item;
+    }
+    // Totally not sure why we need to do this
+    // The code is in need of a deep refactoring T_T
+    if (elemProp && React.isValidElement(elemProp)) {
+      elemProp = { content: elemProp }
     }
     if (item.type === 'elemContent') {
       if (elemProp) {
@@ -145,7 +150,7 @@ const unfoldChildren = function(props, generator) {
       const parents = item.parents || [];
       parents.push(elemName);
       content.parents = parents;
-      if (item.list && elemProp.constructor === Array) {
+      if (item.list && elemProp && elemProp.constructor === Array) {
         const key_prefix = myPropsProps.key + '_';
         return elemProp.map((item, index) => {
           if (typeof item !== 'string') {
@@ -162,14 +167,14 @@ const unfoldChildren = function(props, generator) {
             }
             itemElemProps.key = key_prefix + index;
             itemProps.__BemtoElem.props = itemElemProps
-            return generator(itemProps, item.content)
+            return generator(itemProps, item.content || item)
           } else {
             myPropsProps.key = key_prefix + index;
-            return generator(myProps, ensureArray(item).map(unfoldFunction))
+            return generator(myProps, unfoldFunction(item))
           }
         });
       }
-      return generator(myProps, ensureArray(content).map(unfoldFunction));
+      return generator(myProps, applyToAll(content, unfoldFunction));
     } else if (item.children || item.type === 'children') {
       return props.children;
     };
@@ -192,7 +197,7 @@ const bemto = function(tagString, additionalOptions) {
       };
 
       const children = blockOptions.content
-        ? ensureArray(blockOptions.content).map(unfoldChildren(this.props, generateTag))
+        ? applyToAll(blockOptions.content, unfoldChildren(this.props, generateTag))
         : this.props.children;
       return generateTag(this.props, children);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,13 +109,19 @@ const gatherOptions = function(outerOptions, baseOptions) {
 const unfoldChildren = function(props, generator) {
   const unfoldFunction = function(item, index) {
     const elemName = item.name || item.elem;
-    const elemProp = props['__' + elemName];
+    const elemProp = props['__' + elemName] || item.parents && props['__' + item.parents.filter(name => props['__' + name]).reverse()[0]];
     if (typeof item === 'string') {
       return item;
     }
     if (item.type === 'elemContent') {
-      const matchingElemProp = props['__' + item.parents.filter(name => props['__' + name]).reverse()[0]];
-      return matchingElemProp && matchingElemProp.content || typeof matchingElemProp === 'string' && matchingElemProp;
+      if (elemProp) {
+        if (typeof elemProp === 'string' || elemProp.constructor === Array) {
+          return elemProp;
+        } else {
+          return elemProp.content;
+        }
+      }
+      return;
     }
     if (elemName) {
       if (item.optional && !elemProp) {
@@ -134,12 +140,35 @@ const unfoldChildren = function(props, generator) {
         }
       }, props);
 
-      const content = (!(typeof item.content === 'string' && elemProp) && item.content) || (item.children && { children: true }) || { type: 'elemContent',  name: elemName };
+      const content = (!(typeof item.content === 'string' && elemProp) && item.content) || (item.children && { children: true }) || { type: 'elemContent', name: elemName };
 
       const parents = item.parents || [];
       parents.push(elemName);
       content.parents = parents;
-
+      if (item.list && elemProp.constructor === Array) {
+        const key_prefix = myPropsProps.key + '_';
+        return elemProp.map((item, index) => {
+          if (typeof item !== 'string') {
+            // We need a proper deep clone there lol
+            const itemProps = Object.assign({}, myProps);
+            const itemBemtoElem = {};
+            for (var key in itemProps.__BemtoElem) {
+              itemBemtoElem[key] = itemProps.__BemtoElem[key];
+            }
+            itemProps.__BemtoElem = itemBemtoElem;
+            const itemElemProps = item.props || {};
+            for (var key in itemBemtoElem.props) {
+              itemElemProps[key] = itemBemtoElem.props[key];
+            }
+            itemElemProps.key = key_prefix + index;
+            itemProps.__BemtoElem.props = itemElemProps
+            return generator(itemProps, item.content)
+          } else {
+            myPropsProps.key = key_prefix + index;
+            return generator(myProps, ensureArray(item).map(unfoldFunction))
+          }
+        });
+      }
       return generator(myProps, ensureArray(content).map(unfoldFunction));
     } else if (item.children || item.type === 'children') {
       return props.children;

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,8 @@ const unfoldChildren = function(props, generator) {
       return item;
     }
     if (item.type === 'elemContent') {
-      return props['__' + item.parents.filter(name => props['__' + name])[0]];
+      const matchingElemProp = props['__' + item.parents.filter(name => props['__' + name])[0]];
+      return matchingElemProp && matchingElemProp.content || matchingElemProp;
     }
     if (elemName) {
       if (item.optional && !elemProp) {
@@ -123,10 +124,12 @@ const unfoldChildren = function(props, generator) {
       const parsedTagString = parseTagString(item.tagString);
       if (item.tag) { parsedTagString.tag = item.tag; }
       if (item.className) { parsedTagString.className += ' ' + item.className; }
+      const myPropsProps = elemProp && elemProp.props || {};
+      myPropsProps.key = index;
       const myProps = Object.assign({
         __BemtoElem: {
           name: elemName,
-          props: { key: index },
+          props: myPropsProps,
           parsedTagString: parsedTagString
         }
       }, props);

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,15 +109,14 @@ const gatherOptions = function(outerOptions, baseOptions) {
 const unfoldChildren = function(props, generator) {
   const unfoldFunction = function(item, index) {
     const elemName = item.name || item.elem;
-    const elemProp = elemName && props['__' + elemName];
     if (typeof item === 'string') {
       return item;
     }
     if (item.type === 'elemContent') {
-      return elemProp;
+      return props['__' + item.parents.filter(name => props['__' + name])[0]];
     }
     if (elemName) {
-      if (item.optional && !elemProp) {
+      if (item.optional && !props['__' + elemName]) {
         return;
       }
       const myProps = Object.assign({
@@ -126,10 +125,14 @@ const unfoldChildren = function(props, generator) {
           props: { key: index }
         }
       }, props);
-      if (!item.content && item.children) {
-        item.content = { children: true }
-      }
-      return generator(myProps, ensureArray(item.content || [{ type: 'elemContent',  name: elemName }]).map(unfoldFunction));
+
+      const content = item.content || (item.children && { children: true }) || { type: 'elemContent',  name: elemName };
+
+      const parents = item.parents || [];
+      parents.push(elemName);
+      content.parents = parents;
+
+      return generator(myProps, ensureArray(content).map(unfoldFunction));
     } else if (item.children || item.type === 'children') {
       return props.children;
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,9 @@
 const React = require('react');
 
+// The code below is a mess, I'm sorry. But it is a working mess at least!
+// If you'd want to improve anything: PRs are welcome!
+// And we have tests, don't be afraid to refactor anything.
+
 const modifyClassNames = function(classNames, modifiers) {
   return (classNames + ' ' + classNames.trim().split(/\s+/).map(className => modifiers.map(modifier => className + modifier).join(' ')).join(' ')).trim();
 };
@@ -12,6 +16,7 @@ const gatherModifiers = function(props) {
   return Object.keys(props).filter(prop => props[prop] && prop[0] === '_' && prop[1] !== '_').map(key => typeof props[key] === 'string' ? `${key}_${props[key]}` : key );
 };
 
+// Basic parsing of a tagString
 const parseTagString = function(tagString) {
   const result = {};
   const parsedTagString = typeof tagString === 'string' && tagString.match(/^([^\.\#]*)((?:[\.\#][^\.\#]+)*)$/);
@@ -20,6 +25,7 @@ const parseTagString = function(tagString) {
   return result;
 };
 
+// Base for polymorphic tag names
 const selectTag = function(props, defaultTag) {
   if (typeof defaultTag === 'string') {
     if (props.href) return 'a';
@@ -35,90 +41,115 @@ const selectTag = function(props, defaultTag) {
   return defaultTag;
 };
 
-const ensureProperContent = function(content) {
-  if (content.constructor === Array) return content
-  return [content];
+const ensureArray = function(content) {
+  return content.constructor === Array ? content : [content];
 };
 
-const bemto = function(tagStringOrOptions, optionalOptions) {
-  const blockOptions = optionalOptions || typeof tagStringOrOptions !== 'string' && tagStringOrOptions || {};
-  blockOptions.type = 'block';
-  const tagString = blockOptions.tagString || typeof tagStringOrOptions === 'string' && tagStringOrOptions;
-  const parsedBlockTagString = parseTagString(tagString || '');
-  blockOptions.tag = blockOptions.tag || parsedBlockTagString.tag;
-  blockOptions.props = blockOptions.props || parsedBlockTagString.props || {};
-  blockOptions.props.className = (blockOptions.props.className || blockOptions.className || '')+ ' ' + parsedBlockTagString.className
-  blockOptions.props.id = blockOptions.props.id || blockOptions.id || parsedBlockTagString.id;
+// Recursive unfolder of children for the object to elements generator
+const unfoldChildren = function(props, generator) {
+  const unfoldFunction = function(item, index) {
+    const elemName = item.name || item.elem;
+    if (typeof item === 'string') {
+      return item;
+    }
+    if (item.type === 'elemContent') {
+      return props['__' + elemName];
+    }
+    if (elemName) {
+      const myProps = Object.assign({
+        __BemtoElem: {
+          name: elemName,
+          props: { key: index }
+        }
+      }, props);
+      if (!item.content && item.children) {
+        item.content = { children: true }
+      }
+      return generator(myProps, ensureArray(item.content || [{ type: 'elemContent',  name: elemName }]).map(unfoldFunction));
+    } else if (item.children || item.type === 'children') {
+      return props.children;
+    };
+  }
+  return unfoldFunction;
+};
 
+// Getting the options from the flexible arguments
+// Can accept any of [tagString], [additionalOptions] or [tagString, additionalOptions]
+const collectOptions = function(tagString, additionalOptions) {
+  const options = additionalOptions || typeof tagString !== 'string' && tagString || {};
+  options.type = 'block';
+  options.tagString = options.tagString || typeof tagString === 'string' && tagString;
+  options.parsedTagString = parseTagString(options.tagString || '');
+  options.tag = options.tag || options.parsedTagString.tag;
+  options.props = options.props || options.parsedTagString.props || {};
+  options.props.className = (options.props.className || options.className || '')+ ' ' + options.parsedTagString.className
+  options.props.id = options.props.id || options.id || options.parsedTagString.id;
+  return options;
+};
+
+// Most of the props-handling stuff happens there
+// TODO: refactor this to a few specialized funcions.
+const gatherOptions = function(outerOptions, baseOptions) {
+  // Clone & merge options from arguments
+  const options = Object.assign(baseOptions, outerOptions);
+  options.props = Object.assign({}, outerOptions.props);
+
+  // Modify options if we're at elem scope
+  options.elem = options.tagProps.__BemtoElem;
+  if (options.elem) {
+    options.type = 'elem';
+    const elemParsedTagString = options.elem.parsedTagString || parseTagString(options.elem.tagString || '');
+    if (elemParsedTagString.tag) {
+      options.tag = elemParsedTagString.tag;
+    }
+    if (elemParsedTagString.id) {
+      options.props.id = elemParsedTagString.id;
+    }
+    options.props.className = elemParsedTagString.className || '';
+  }
+
+  options.finalProps = {};
+  for (var key in (options.elem && (options.elem.props || {}) || options.tagProps)) {
+    if (!(typeof options.tag === 'string' && key[0] === '_') && key !== 'children') {
+      options.finalProps[key] = (options.elem && (options.elem.props || {}) || options.tagProps)[key];
+    }
+  }
+
+  if (options.props.id && !options.finalProps.id) {
+    options.finalProps.id = options.props.id;
+  }
+
+  if (options.elem) {
+    options.finalProps.className = (options.finalProps.className || '') + ' ' + createElemClassNames(((options.tagProps.className || '') + ' ' + options.parsedTagString.className), [options.elem.name]);
+  }
+
+  options.finalProps.className = modifyClassNames((options.finalProps.className || '') + ' ' + options.props.className, gatherModifiers(options.elem && (options.elem.props || {}) || options.tagProps));
+
+  // FIXME: replace with joining className_s_ (which don't exist yet)
+  options.finalProps.className = options.finalProps.className.replace(/\s{2,}/g, ' ');
+
+  options.finalTag = selectTag(options.finalProps, options.tag);
+
+  return options;
+}
+
+// Our main factory
+const bemto = function(tagString, additionalOptions) {
+  const blockOptions = collectOptions(tagString, additionalOptions);
   const bemtoFactory = class bemtoTag extends React.Component {
     render() {
-      const generateTag = (tagProps, children) => {
-        const options = Object.assign({}, blockOptions);
-        options.props = Object.assign({}, blockOptions.props);
-        const elem = tagProps.__BemtoElem;
-        if (elem) {
-          options.type = 'elem';
-          const elemParsedTagString = elem.parsedTagString || parseTagString(elem.tagString || '');
-          if (elemParsedTagString.tag) {
-            options.tag = elemParsedTagString.tag;
-          }
-          if (elemParsedTagString.id) {
-            options.props.id = elemParsedTagString.id;
-          }
-          options.props.className = elemParsedTagString.className || '';
-        }
+      const generateTag = (props, children) => {
+        const options = gatherOptions(blockOptions, {
+          tagProps: props,
+          children: children
+        })
 
-        const props = {};
-        for (var key in (elem && (elem.props || {}) || tagProps)) {
-          if (!(typeof options.tag === 'string' && key[0] === '_') && key !== 'children') {
-            props[key] = (elem && (elem.props || {}) || tagProps)[key];
-          }
-        }
-
-        if (options.props.id && !props.id) {
-          props.id = options.props.id;
-        }
-
-        if (elem) {
-          props.className = (props.className || '') + ' ' + createElemClassNames(((tagProps.className || '') + ' ' + parsedBlockTagString.className), [elem.name]);
-        }
-
-        props.className = modifyClassNames((props.className || '') + ' ' + options.props.className, gatherModifiers(elem && (elem.props || {}) || tagProps));
-
-        // FIXME: replace with joining className_s_ (which don't exist yet)
-        props.className = props.className.replace(/\s{2,}/g, ' ');
-
-        return React.createElement(selectTag(props, options.tag), props, children);
+        return React.createElement(options.finalTag, options.finalProps, options.children);
       };
 
-      let children = this.props.children;
-      if (blockOptions.content) {
-        const unfoldChildren = (item, index) => {
-          const elemName = item.name || item.elem;
-          if (typeof item === 'string') {
-            return item;
-          }
-          if (item.type === 'elemContent') {
-            return this.props['__' + elemName];
-          }
-          if (elemName) {
-            const myProps = Object.assign({
-              // TODO: add __ElemProps ?
-              __BemtoElem: {
-                name: elemName,
-                props: { key: index }
-              }
-            }, this.props);
-            if (!item.content && item.children) {
-              item.content = { children: true }
-            }
-            return generateTag(myProps, ensureProperContent(item.content || [{ type: 'elemContent',  name: elemName }]).map(unfoldChildren));
-          } else if (item.children || item.type === 'children') {
-            return this.props.children;
-          };
-        }
-        children = ensureProperContent(blockOptions.content).map(unfoldChildren);
-      }
+      const children = blockOptions.content
+        ? ensureArray(blockOptions.content).map(unfoldChildren(this.props, generateTag))
+        : this.props.children;
       return generateTag(this.props, children);
     }
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ const unfoldChildren = function(props, generator) {
         return;
       }
       const parsedTagString = parseTagString(item.tagString);
-      if (item.tag) { parsedTagString.tag = item.tag; }
+      parsedTagString.tag = item.tag || 'div';
       if (item.className) { parsedTagString.className += ' ' + item.className; }
       const myPropsProps = elemProp && elemProp.props || {};
       myPropsProps.key = index;

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,7 @@ const gatherOptions = function(outerOptions, baseOptions) {
 const unfoldChildren = function(props, generator) {
   const unfoldFunction = function(item, index) {
     const elemName = item.name || item.elem;
+    const elemProp = props['__' + elemName];
     if (typeof item === 'string') {
       return item;
     }
@@ -116,7 +117,7 @@ const unfoldChildren = function(props, generator) {
       return props['__' + item.parents.filter(name => props['__' + name])[0]];
     }
     if (elemName) {
-      if (item.optional && !props['__' + elemName]) {
+      if (item.optional && !elemProp) {
         return;
       }
       const myProps = Object.assign({
@@ -126,7 +127,7 @@ const unfoldChildren = function(props, generator) {
         }
       }, props);
 
-      const content = item.content || (item.children && { children: true }) || { type: 'elemContent',  name: elemName };
+      const content = (!(typeof item.content === 'string' && elemProp) && item.content) || (item.children && { children: true }) || { type: 'elemContent',  name: elemName };
 
       const parents = item.parents || [];
       parents.push(elemName);

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,34 +45,6 @@ const ensureArray = function(content) {
   return content.constructor === Array ? content : [content];
 };
 
-// Recursive unfolder of children for the object to elements generator
-const unfoldChildren = function(props, generator) {
-  const unfoldFunction = function(item, index) {
-    const elemName = item.name || item.elem;
-    if (typeof item === 'string') {
-      return item;
-    }
-    if (item.type === 'elemContent') {
-      return props['__' + elemName];
-    }
-    if (elemName) {
-      const myProps = Object.assign({
-        __BemtoElem: {
-          name: elemName,
-          props: { key: index }
-        }
-      }, props);
-      if (!item.content && item.children) {
-        item.content = { children: true }
-      }
-      return generator(myProps, ensureArray(item.content || [{ type: 'elemContent',  name: elemName }]).map(unfoldFunction));
-    } else if (item.children || item.type === 'children') {
-      return props.children;
-    };
-  }
-  return unfoldFunction;
-};
-
 // Getting the options from the flexible arguments
 // Can accept any of [tagString], [additionalOptions] or [tagString, additionalOptions]
 const collectOptions = function(tagString, additionalOptions) {
@@ -132,6 +104,38 @@ const gatherOptions = function(outerOptions, baseOptions) {
 
   return options;
 }
+
+// Recursive unfolder of children for the object to elements generator
+const unfoldChildren = function(props, generator) {
+  const unfoldFunction = function(item, index) {
+    const elemName = item.name || item.elem;
+    const elemProp = elemName && props['__' + elemName];
+    if (typeof item === 'string') {
+      return item;
+    }
+    if (item.type === 'elemContent') {
+      return elemProp;
+    }
+    if (elemName) {
+      if (item.optional && !elemProp) {
+        return;
+      }
+      const myProps = Object.assign({
+        __BemtoElem: {
+          name: elemName,
+          props: { key: index }
+        }
+      }, props);
+      if (!item.content && item.children) {
+        item.content = { children: true }
+      }
+      return generator(myProps, ensureArray(item.content || [{ type: 'elemContent',  name: elemName }]).map(unfoldFunction));
+    } else if (item.children || item.type === 'children') {
+      return props.children;
+    };
+  }
+  return unfoldFunction;
+};
 
 // Our main factory
 const bemto = function(tagString, additionalOptions) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,11 @@ const selectTag = function(props, defaultTag) {
   return defaultTag;
 };
 
+const ensureProperContent = function(content) {
+  if (content.constructor === Array) return content
+  return [content];
+};
+
 const bemto = function(tagStringOrOptions, optionalOptions) {
   const blockOptions = optionalOptions || typeof tagStringOrOptions !== 'string' && tagStringOrOptions || {};
   blockOptions.type = 'block';
@@ -89,22 +94,30 @@ const bemto = function(tagStringOrOptions, optionalOptions) {
       let children = this.props.children;
       if (blockOptions.content) {
         const unfoldChildren = (item, index) => {
-          if (item.type === 'children') {
-            return this.props.children;
-          } else if (item.type === 'elem') {
+          const elemName = item.name || item.elem;
+          if (typeof item === 'string') {
+            return item;
+          }
+          if (item.type === 'elemContent') {
+            return this.props['__' + elemName];
+          }
+          if (elemName) {
             const myProps = Object.assign({
               // TODO: add __ElemProps ?
               __BemtoElem: {
-                name: item.name,
+                name: elemName,
                 props: { key: index }
               }
             }, this.props);
-            return generateTag(myProps, (item.content || [{ type: 'elemContent',  name: item.name }]).map(unfoldChildren));
-          } else if (item.type === 'elemContent') {
-            return this.props['__' + item.name];
+            if (!item.content && item.children) {
+              item.content = { children: true }
+            }
+            return generateTag(myProps, ensureProperContent(item.content || [{ type: 'elemContent',  name: elemName }]).map(unfoldChildren));
+          } else if (item.children || item.type === 'children') {
+            return this.props.children;
           };
         }
-        children = blockOptions.content.map(unfoldChildren);
+        children = ensureProperContent(blockOptions.content).map(unfoldChildren);
       }
       return generateTag(this.props, children);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ const selectTag = function(props, defaultTag) {
 };
 
 const applyToAll = function(content, func) {
-  return (content.constructor === Array) ? content.map(func) : func(content);
+  return (content && content.constructor === Array) ? content.map(func) : func(content);
 };
 
 // Getting the options from the flexible arguments
@@ -120,7 +120,7 @@ const unfoldChildren = function(props, generator) {
     }
     if (item.type === 'elemContent') {
       if (elemProp) {
-        if (typeof elemProp === 'string' || elemProp.constructor === Array) {
+        if (typeof elemProp === 'string' || elemProp && elemProp.constructor === Array) {
           return elemProp;
         } else {
           return elemProp.content;

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,40 +47,66 @@ const bemto = function(tagStringOrOptions, optionalOptions) {
 
   const bemtoFactory = class bemtoTag extends React.Component {
     render() {
-      const options = Object.assign({}, blockOptions);
-      const elem = this.props.__BemtoElem;
-      if (elem) {
-        options.type = 'elem';
-        const elemParsedTagString = elem.parsedTagString || parseTagString(elem.tagString || '');
-        if (elemParsedTagString.tag) {
-          options.tag = elemParsedTagString.tag;
+      const generateTag = (tagProps, children) => {
+        const options = Object.assign({}, blockOptions);
+        options.props = Object.assign({}, blockOptions.props);
+        const elem = tagProps.__BemtoElem;
+        if (elem) {
+          options.type = 'elem';
+          const elemParsedTagString = elem.parsedTagString || parseTagString(elem.tagString || '');
+          if (elemParsedTagString.tag) {
+            options.tag = elemParsedTagString.tag;
+          }
+          if (elemParsedTagString.id) {
+            options.props.id = elemParsedTagString.id;
+          }
+          options.props.className = elemParsedTagString.className || '';
         }
-        if (elemParsedTagString.id) {
-          options.props.id = elemParsedTagString.id;
+
+        const props = {};
+        for (var key in (elem && (elem.props || {}) || tagProps)) {
+          if (!(typeof options.tag === 'string' && key[0] === '_') && key !== 'children') {
+            props[key] = (elem && (elem.props || {}) || tagProps)[key];
+          }
         }
-        options.props.className = elemParsedTagString.className || '';
-      }
 
-      const props = {};
-      for (var key in (elem && (elem.props || {}) || this.props)) {
-        if (!(typeof options.tag === 'string' && key[0] === '_') && key !== 'children') {
-          props[key] = (elem && (elem.props || {}) || this.props)[key];
+        if (options.props.id && !props.id) {
+          props.id = options.props.id;
         }
+
+        if (elem) {
+          props.className = (props.className || '') + ' ' + createElemClassNames(((tagProps.className || '') + ' ' + parsedBlockTagString.className), [elem.name]);
+        }
+
+        props.className = modifyClassNames((props.className || '') + ' ' + options.props.className, gatherModifiers(elem && (elem.props || {}) || tagProps));
+
+        // FIXME: replace with joining className_s_ (which don't exist yet)
+        props.className = props.className.replace(/\s{2,}/g, ' ');
+
+        return React.createElement(selectTag(props, options.tag), props, children);
+      };
+
+      let children = this.props.children;
+      if (blockOptions.content) {
+        const unfoldChildren = (item, index) => {
+          if (item.type === 'children') {
+            return this.props.children;
+          } else if (item.type === 'elem') {
+            const myProps = Object.assign({
+              // TODO: add __ElemProps ?
+              __BemtoElem: {
+                name: item.name,
+                props: { key: index }
+              }
+            }, this.props);
+            return generateTag(myProps, (item.content || [{ type: 'elemContent',  name: item.name }]).map(unfoldChildren));
+          } else if (item.type === 'elemContent') {
+            return this.props['__' + item.name];
+          };
+        }
+        children = blockOptions.content.map(unfoldChildren);
       }
-
-      if (options.props.id && !props.id) {
-        props.id = options.props.id;
-      }
-
-      if (elem) {
-        props.className = (props.className || '') + ' ' + createElemClassNames((this.props.className || ' ' + parsedBlockTagString.className), [elem.name]);
-      }
-
-      props.className = modifyClassNames((props.className || '') + ' ' + options.props.className, gatherModifiers(elem && (elem.props || {}) || this.props));
-
-      // FIXME: replace with joining className_s_ (which don't exist yet)
-      props.className = props.className.replace(/\s{2,}/g, ' ');
-      return React.createElement(selectTag(props, options.tag), props, this.props.children);
+      return generateTag(this.props, children);
     }
   };
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`block with passing content to an element through props 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    Hello, helper!
+  </div>
+  children text
+</div>
+`;
+
 exports[`should NOT become a button as a non-neutral type given 1`] = `
 <input
   className="myButton"
@@ -61,6 +74,59 @@ exports[`should become an image based on an attrubute 1`] = `
   className="myImage"
   src="kitten.jpg"
 />
+`;
+
+exports[`simple block with a Before, and a complex After, and a modifier, and an extraClass 1`] = `
+<div
+  className="extraClass myBlock extraClass_mod myBlock_mod"
+>
+  <div
+    className="extraClass__Before myBlock__Before"
+  />
+  <div
+    className="ChildBlock"
+  >
+    some inner text
+  </div>
+  <div
+    className="extraClass__After myBlock__After"
+  >
+    <div
+      className="extraClass__After__Inner myBlock__After__Inner"
+    />
+  </div>
+</div>
+`;
+
+exports[`simple block with a Content wrapper 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Content"
+  >
+    children text
+  </div>
+</div>
+`;
+
+exports[`simple block with a Helper item before children 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  />
+  children text
+</div>
+`;
+
+exports[`simple block with defaulty content 1`] = `
+<div
+  className="myBlock"
+>
+  children text
+</div>
 `;
 
 exports[`with block that has multiple classes and with an element that has a tagString 1`] = `

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`block with a more complex list system inside 1`] = `
+<div
+  className="myBlock"
+>
+  <ul
+    className="myBlock__List"
+  >
+    <li
+      className="myBlock__Item"
+    >
+      lol
+    </li>
+    <li
+      className="myBlock__Item"
+    >
+      whatever
+    </li>
+  </ul>
+  children text
+</div>
+`;
+
+exports[`block with a more complex list system inside, now with props O_O 1`] = `
+<div
+  className="myBlock"
+>
+  <ul
+    className="myBlock__List"
+  >
+    <li
+      className="myBlock__Item myBlock__Item_mod"
+    >
+      lol
+    </li>
+    <li
+      className="myBlock__Item"
+    >
+      whatever
+    </li>
+  </ul>
+  children text
+</div>
+`;
+
 exports[`block with a single wrapper inside without an array 1`] = `
 <div
   className="myBlock"
@@ -21,6 +65,38 @@ exports[`block with a single wrapper inside without an array with shorter childr
   >
     children text
   </div>
+</div>
+`;
+
+exports[`block with an array as the content of an element 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    lol
+    whatever
+  </div>
+  children text
+</div>
+`;
+
+exports[`block with an array as the content of an element, but as a list 1`] = `
+<div
+  className="myList"
+>
+  <div
+    className="myList__Item"
+  >
+    lol
+  </div>
+  <div
+    className="myList__Item"
+  >
+    whatever
+  </div>
+  children text
 </div>
 `;
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`block with a single wrapper inside without an array 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Content"
+  >
+    children text
+  </div>
+</div>
+`;
+
+exports[`block with a single wrapper inside without an array with shorter children syntax 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Content"
+  >
+    children text
+  </div>
+</div>
+`;
+
 exports[`block with passing content to an element through props 1`] = `
 <div
   className="myBlock"
@@ -117,6 +141,19 @@ exports[`simple block with a Helper item before children 1`] = `
   <div
     className="myBlock__Helper"
   />
+  children text
+</div>
+`;
+
+exports[`simple block with a Helper item that have a string content 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    I am a helper
+  </div>
   children text
 </div>
 `;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -158,6 +158,19 @@ exports[`simple block with a Helper item that have a string content 1`] = `
 </div>
 `;
 
+exports[`simple block with a Helper item that have a string content which is later overrided 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    Overriding content!
+  </div>
+  children text
+</div>
+`;
+
 exports[`simple block with an optional Helper item that should be rendered as it was passed on call 1`] = `
 <div
   className="myBlock"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -134,6 +134,42 @@ exports[`simple block with a Content wrapper 1`] = `
 </div>
 `;
 
+exports[`simple block with a Content wrapper which is a span 1`] = `
+<div
+  className="myBlock"
+>
+  <span
+    className="myBlock__Content"
+  >
+    children text
+  </span>
+</div>
+`;
+
+exports[`simple block with a Content wrapper which is a span and have an extra class 1`] = `
+<div
+  className="myBlock"
+>
+  <span
+    className="myBlock__Content extraContentClassname"
+  >
+    children text
+  </span>
+</div>
+`;
+
+exports[`simple block with a Content wrapper which is a span and have an extra class via tagString 1`] = `
+<div
+  className="myBlock"
+>
+  <span
+    className="myBlock__Content extraContentClassname"
+  >
+    children text
+  </span>
+</div>
+`;
+
 exports[`simple block with a Helper item before children 1`] = `
 <div
   className="myBlock"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -179,6 +179,31 @@ exports[`simple block with an optional Helper item that should not be rendered 1
 </div>
 `;
 
+exports[`simple block with an optional nested Helper item that should be properly rendered 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    <div
+      className="myBlock__Helper__Content"
+    >
+      I am a Helper
+    </div>
+  </div>
+  children text
+</div>
+`;
+
+exports[`simple block with an optional nested Helper item that should not be rendered 1`] = `
+<div
+  className="myBlock"
+>
+  children text
+</div>
+`;
+
 exports[`simple block with defaulty content 1`] = `
 <div
   className="myBlock"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -37,6 +37,33 @@ exports[`block with passing content to an element through props 1`] = `
 </div>
 `;
 
+exports[`block with passing content to an element through props using an object 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    Hello, helper!
+  </div>
+  children text
+</div>
+`;
+
+exports[`block with passing content to an element through props using an object with props 1`] = `
+<div
+  className="myBlock"
+>
+  <a
+    className="myBlock__Helper myBlock__Helper_elemMod"
+    href="#x"
+  >
+    Hello, helper!
+  </a>
+  children text
+</div>
+`;
+
 exports[`should NOT become a button as a non-neutral type given 1`] = `
 <input
   className="myButton"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -234,6 +234,46 @@ exports[`simple block with a Helper item that have a string content which is lat
 </div>
 `;
 
+exports[`simple block with a nested Helper item that should be rendered with diff modifiers on diff elements 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper myBlock__Helper_a1"
+  >
+    <div
+      className="myBlock__Helper2 myBlock__Helper2_a2"
+    >
+      <div
+        className="myBlock__Helper3 myBlock__Helper3_a3"
+      />
+    </div>
+  </div>
+  children text
+</div>
+`;
+
+exports[`simple block with a nested Helper item that should have proper content rendered 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    <div
+      className="myBlock__Helper2"
+    >
+      <div
+        className="myBlock__Helper3"
+      >
+        rendered
+      </div>
+    </div>
+  </div>
+  children text
+</div>
+`;
+
 exports[`simple block with an optional Helper item that should be rendered as it was passed on call 1`] = `
 <div
   className="myBlock"
@@ -243,6 +283,28 @@ exports[`simple block with an optional Helper item that should be rendered as it
   >
     I am a Helper
   </div>
+  children text
+</div>
+`;
+
+exports[`simple block with an optional Helper item that should be rendered as it was passed on call but as a boolean 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  />
+  children text
+</div>
+`;
+
+exports[`simple block with an optional Helper item that should be rendered as it was passed on call but as an contentless object with a modifier 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper myBlock__Helper_elmo_whee"
+  />
   children text
 </div>
 `;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -158,6 +158,27 @@ exports[`simple block with a Helper item that have a string content 1`] = `
 </div>
 `;
 
+exports[`simple block with an optional Helper item that should be rendered as it was passed on call 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    I am a Helper
+  </div>
+  children text
+</div>
+`;
+
+exports[`simple block with an optional Helper item that should not be rendered 1`] = `
+<div
+  className="myBlock"
+>
+  children text
+</div>
+`;
+
 exports[`simple block with defaulty content 1`] = `
 <div
   className="myBlock"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -100,6 +100,43 @@ exports[`block with an array as the content of an element, but as a list 1`] = `
 </div>
 `;
 
+exports[`block with passing content to an element through props (passing a list of proper elements) 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    <span
+      className="helperContent1"
+    />
+  </div>
+  <div
+    className="myBlock__Helper"
+  >
+    <span
+      className="helperContent2"
+    />
+  </div>
+  children text
+</div>
+`;
+
+exports[`block with passing content to an element through props (passing proper element) 1`] = `
+<div
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  >
+    <span
+      className="helperContent"
+    />
+  </div>
+  children text
+</div>
+`;
+
 exports[`block with passing content to an element through props 1`] = `
 <div
   className="myBlock"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -189,11 +189,11 @@ exports[`simple block with a Content wrapper which is a span and have an extra c
 <div
   className="myBlock"
 >
-  <span
+  <div
     className="myBlock__Content extraContentClassname"
   >
     children text
-  </span>
+  </div>
 </div>
 `;
 
@@ -206,6 +206,17 @@ exports[`simple block with a Helper item before children 1`] = `
   />
   children text
 </div>
+`;
+
+exports[`simple block with a Helper item before children using a button tag on parent 1`] = `
+<button
+  className="myBlock"
+>
+  <div
+    className="myBlock__Helper"
+  />
+  children text
+</button>
 `;
 
 exports[`simple block with a Helper item that have a string content 1`] = `

--- a/test/test.js
+++ b/test/test.js
@@ -297,7 +297,7 @@ test('with element created through __BemtoElem prop with more extensive options 
 test('simple block with defaulty content', () => {
   testSnapshot(
     bemto('.myBlock', {
-      content: [{ type: 'children' }]
+      content: [{ children: true }]
     }),
     {},
     'children text'
@@ -308,9 +308,8 @@ test('simple block with a Content wrapper', () => {
   testSnapshot(
     bemto('.myBlock', {
       content: [{
-        type: 'elem',
-        name: 'Content',
-        content: [{ type: 'children' }]
+        elem: 'Content',
+        content: [{ children: true }]
       }]
     }),
     {},
@@ -323,11 +322,10 @@ test('simple block with a Helper item before children', () => {
     bemto('.myBlock', {
       content: [
         {
-          type: 'elem',
-          name: 'Helper'
+          elem: 'Helper'
         },
         {
-          type: 'children'
+          children: true
         }
       ]
     }),
@@ -341,18 +339,15 @@ test('simple block with a Before, and a complex After, and a modifier, and an ex
     bemto('.myBlock', {
       content: [
         {
-          type: 'elem',
-          name: 'Before'
+          elem: 'Before'
         },
         {
-          type: 'children'
+          children: true
         },
         {
-          type: 'elem',
-          name: 'After',
+          elem: 'After',
           content: [{
-            type: 'elem',
-            name: 'After__Inner'
+            elem: 'After__Inner'
           }]
         }
       ]
@@ -366,11 +361,10 @@ test('block with passing content to an element through props', () => {
   const MyBlock = bemto('.myBlock', {
     content: [
       {
-        type: 'elem',
-        name: 'Helper'
+        elem: 'Helper'
       },
       {
-        type: 'children'
+        children: true
       }
     ]
   });
@@ -379,6 +373,52 @@ test('block with passing content to an element through props', () => {
     {
       __Helper: 'Hello, helper!'
     },
+    'children text'
+  );
+});
+
+test('block with a single wrapper inside without an array', () => {
+  const MyBlock = bemto('.myBlock', {
+    content: {
+      elem: 'Content',
+      content: { children: true }
+    }
+  });
+  testSnapshot(
+    MyBlock,
+    {},
+    'children text'
+  );
+});
+
+test('block with a single wrapper inside without an array with shorter children syntax', () => {
+  const MyBlock = bemto('.myBlock', {
+    content: {
+      elem: 'Content',
+      children: true
+    }
+  });
+  testSnapshot(
+    MyBlock,
+    {},
+    'children text'
+  );
+});
+
+test('simple block with a Helper item that have a string content', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          content: 'I am a helper'
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {},
     'children text'
   );
 });

--- a/test/test.js
+++ b/test/test.js
@@ -420,6 +420,54 @@ test('block with passing content to an element through props', () => {
   );
 });
 
+test('block with passing content to an element through props using an object', () => {
+  const MyBlock = bemto('.myBlock', {
+    content: [
+      {
+        elem: 'Helper'
+      },
+      {
+        children: true
+      }
+    ]
+  });
+  testSnapshot(
+    MyBlock,
+    {
+      __Helper: {
+        content: 'Hello, helper!'
+      }
+    },
+    'children text'
+  );
+});
+
+test('block with passing content to an element through props using an object with props', () => {
+  const MyBlock = bemto('.myBlock', {
+    content: [
+      {
+        elem: 'Helper'
+      },
+      {
+        children: true
+      }
+    ]
+  });
+  testSnapshot(
+    MyBlock,
+    {
+      __Helper: {
+        content: 'Hello, helper!',
+        props: {
+          _elemMod: true,
+          href: '#x'
+        }
+      }
+    },
+    'children text'
+  );
+});
+
 test('block with a single wrapper inside without an array', () => {
   const MyBlock = bemto('.myBlock', {
     content: {

--- a/test/test.js
+++ b/test/test.js
@@ -422,3 +422,39 @@ test('simple block with a Helper item that have a string content', () => {
     'children text'
   );
 });
+
+test('simple block with an optional Helper item that should not be rendered', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          optional: true
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {},
+    'children text'
+  );
+});
+
+test('simple block with an optional Helper item that should be rendered as it was passed on call', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          optional: true
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    { __Helper: 'I am a Helper' },
+    'children text'
+  );
+});

--- a/test/test.js
+++ b/test/test.js
@@ -458,3 +458,45 @@ test('simple block with an optional Helper item that should be rendered as it wa
     'children text'
   );
 });
+
+test('simple block with an optional nested Helper item that should not be rendered', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          optional: true,
+          content: {
+            elem: 'Helper__Content'
+          }
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {},
+    'children text'
+  );
+});
+
+test('simple block with an optional nested Helper item that should be properly rendered', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          optional: true,
+          content: {
+            elem: 'Helper__Content'
+          }
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    { __Helper: 'I am a Helper' },
+    'children text'
+  );
+});

--- a/test/test.js
+++ b/test/test.js
@@ -423,6 +423,26 @@ test('simple block with a Helper item that have a string content', () => {
   );
 });
 
+test('simple block with a Helper item that have a string content which is later overrided', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          content: 'I am a helper'
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {
+      __Helper: 'Overriding content!'
+    },
+    'children text'
+  );
+});
+
 test('simple block with an optional Helper item that should not be rendered', () => {
   testSnapshot(
     bemto('.myBlock', {

--- a/test/test.js
+++ b/test/test.js
@@ -377,6 +377,23 @@ test('simple block with a Helper item before children', () => {
   );
 });
 
+test('simple block with a Helper item before children using a button tag on parent', () => {
+  testSnapshot(
+    bemto('button.myBlock', {
+      content: [
+        {
+          elem: 'Helper'
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {},
+    'children text'
+  );
+});
+
 test('simple block with a Before, and a complex After, and a modifier, and an extraClass', () => {
   testSnapshot(
     bemto('.myBlock', {

--- a/test/test.js
+++ b/test/test.js
@@ -293,3 +293,92 @@ test('with element created through __BemtoElem prop with more extensive options 
     }})
   );
 });
+
+test('simple block with defaulty content', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [{ type: 'children' }]
+    }),
+    {},
+    'children text'
+  );
+});
+
+test('simple block with a Content wrapper', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [{
+        type: 'elem',
+        name: 'Content',
+        content: [{ type: 'children' }]
+      }]
+    }),
+    {},
+    'children text'
+  );
+});
+
+test('simple block with a Helper item before children', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          type: 'elem',
+          name: 'Helper'
+        },
+        {
+          type: 'children'
+        }
+      ]
+    }),
+    {},
+    'children text'
+  );
+});
+
+test('simple block with a Before, and a complex After, and a modifier, and an extraClass', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          type: 'elem',
+          name: 'Before'
+        },
+        {
+          type: 'children'
+        },
+        {
+          type: 'elem',
+          name: 'After',
+          content: [{
+            type: 'elem',
+            name: 'After__Inner'
+          }]
+        }
+      ]
+    }),
+    { className: 'extraClass', _mod: true },
+    React.createElement(bemto('.ChildBlock'), {}, 'some inner text')
+  );
+});
+
+test('block with passing content to an element through props', () => {
+  const MyBlock = bemto('.myBlock', {
+    content: [
+      {
+        type: 'elem',
+        name: 'Helper'
+      },
+      {
+        type: 'children'
+      }
+    ]
+  });
+  testSnapshot(
+    MyBlock,
+    {
+      __Helper: 'Hello, helper!'
+    },
+    'children text'
+  );
+});

--- a/test/test.js
+++ b/test/test.js
@@ -570,6 +570,95 @@ test('simple block with an optional Helper item that should be rendered as it wa
   );
 });
 
+test('simple block with an optional Helper item that should be rendered as it was passed on call but as a boolean', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          optional: true
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    { __Helper: true },
+    'children text'
+  );
+});
+
+test('simple block with an optional Helper item that should be rendered as it was passed on call but as an contentless object with a modifier', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          optional: true
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    { __Helper: { props: { _elmo: 'whee'} } },
+    'children text'
+  );
+});
+
+test('simple block with a nested Helper item that should be rendered with diff modifiers on diff elements', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          content: {
+            elem: 'Helper2',
+            content: {
+              elem: 'Helper3'
+            }
+          }
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {
+      __Helper: { props: { _a1: true} },
+      __Helper2: { props: { _a2: true} },
+      __Helper3: { props: { _a3: true} }
+    },
+    'children text'
+  );
+});
+
+test('simple block with a nested Helper item that should have proper content rendered', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper',
+          content: {
+            elem: 'Helper2',
+            content: {
+              elem: 'Helper3'
+            }
+          }
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {
+      __Helper: "not rendered",
+      __Helper3: "rendered"
+    },
+    'children text'
+  );
+});
+
 test('simple block with an optional nested Helper item that should not be rendered', () => {
   testSnapshot(
     bemto('.myBlock', {

--- a/test/test.js
+++ b/test/test.js
@@ -437,6 +437,50 @@ test('block with passing content to an element through props', () => {
   );
 });
 
+test('block with passing content to an element through props (passing proper element)', () => {
+  const MyBlock = bemto('.myBlock', {
+    content: [
+      {
+        elem: 'Helper'
+      },
+      {
+        children: true
+      }
+    ]
+  });
+  testSnapshot(
+    MyBlock,
+    {
+      __Helper: React.createElement(bemto('span.helperContent'))
+    },
+    'children text'
+  );
+});
+
+test('block with passing content to an element through props (passing a list of proper elements)', () => {
+  const MyBlock = bemto('.myBlock', {
+    content: [
+      {
+        elem: 'Helper',
+        list: true
+      },
+      {
+        children: true
+      }
+    ]
+  });
+  testSnapshot(
+    MyBlock,
+    {
+      __Helper: [
+        React.createElement(bemto('span.helperContent1')),
+        React.createElement(bemto('span.helperContent2'))
+      ]
+    },
+    'children text'
+  );
+});
+
 test('block with passing content to an element through props using an object', () => {
   const MyBlock = bemto('.myBlock', {
     content: [

--- a/test/test.js
+++ b/test/test.js
@@ -717,3 +717,91 @@ test('simple block with an optional nested Helper item that should be properly 
     'children text'
   );
 });
+
+test('block with an array as the content of an element', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'Helper'
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    { __Helper: ['lol', 'whatever'] },
+    'children text'
+  );
+});
+
+test('block with an array as the content of an element, but as a list', () => {
+  testSnapshot(
+    bemto('.myList', {
+      content: [
+        {
+          elem: 'Item',
+          list: true
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    { __Item: ['lol', 'whatever'] },
+    'children text'
+  );
+});
+
+test('block with a more complex list system inside', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'List',
+          tag: 'ul',
+          optional: true,
+          content: {
+            elem: 'Item',
+            tag: 'li',
+            list: true
+          }
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    { __List: ['lol', 'whatever'] },
+    'children text'
+  );
+});
+
+test('block with a more complex list system inside, now with props O_O', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [
+        {
+          elem: 'List',
+          tag: 'ul',
+          optional: true,
+          content: {
+            elem: 'Item',
+            tag: 'li',
+            list: true
+          }
+        },
+        {
+          children: true
+        }
+      ]
+    }),
+    {
+      __List: [
+        { content: 'lol', props: { _mod: true } },
+        { content: 'whatever' }
+      ]
+    },
+    'children text'
+  );
+});

--- a/test/test.js
+++ b/test/test.js
@@ -317,6 +317,49 @@ test('simple block with a Content wrapper', () => {
   );
 });
 
+test('simple block with a Content wrapper which is a span', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [{
+        elem: 'Content',
+        tag: 'span',
+        content: [{ children: true }]
+      }]
+    }),
+    {},
+    'children text'
+  );
+});
+
+test('simple block with a Content wrapper which is a span and have an extra class', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [{
+        elem: 'Content',
+        tag: 'span',
+        className: 'extraContentClassname',
+        content: [{ children: true }]
+      }]
+    }),
+    {},
+    'children text'
+  );
+});
+
+test('simple block with a Content wrapper which is a span and have an extra class via tagString', () => {
+  testSnapshot(
+    bemto('.myBlock', {
+      content: [{
+        elem: 'Content',
+        tagString: 'span.extraContentClassname',
+        content: [{ children: true }]
+      }]
+    }),
+    {},
+    'children text'
+  );
+});
+
 test('simple block with a Helper item before children', () => {
   testSnapshot(
     bemto('.myBlock', {


### PR DESCRIPTION
Without the tagString parsing for now probably, but with the way to do it by passing the options with the proper object.

Left to do:

- [x] Docs!
- [x] Arrays as elements content.
- [x] Optional way to use element as a wrapper for each of passed array item.
- [x] Refactor code a bit, its now a mess, it could be a mess less.
- [x] `__Elem` prop helper should accept not just the element, but also object with the options for this element.
- [x] Elements should have an option to be optional: they could render only when there is content for them.
- [x] There should be a default but overridable content for those elements.
- [x] Check if all the stuff like polymorphic stuff works for those elements as well.
- [x] `content` in a bemto object should be able to be just an object/string/etc. and shouldn't be always be wrapped by an array.
